### PR TITLE
Fix StudyScreen data path

### DIFF
--- a/screens/Common/StudyScreen.tsx
+++ b/screens/Common/StudyScreen.tsx
@@ -20,7 +20,7 @@ export default function StudyScreen() {
     const loadChapters = async () => {
       try {
         // Load chapters from our JSON file
-        const chaptersData = require('../data/chapters.json');
+        const chaptersData = require('../../data/chapters.json');
         setChapters(chaptersData.chapters);
       } catch (error) {
         console.error('Failed to load chapters:', error);


### PR DESCRIPTION
## Summary
- fix incorrect path to `chapters.json` in StudyScreen

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f47e8188c8322a1a7eea8e24bf944